### PR TITLE
Fix API port mismatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ docker exec -it ansible_runner bash
 ### ▶️ Example: Run a playbook
 
 ```shell
-curl -X POST "http://localhost:5000/run" \
+curl -X POST "http://localhost:5001/run" \
   -u admin:supersecret \
   -H "Content-Type: application/json" \
   -d '{"playbook": "playbook1.yml"}'
@@ -71,7 +71,7 @@ curl -X POST "http://localhost:5000/run" \
 ### ▶️ Example: Health check
 
 ```shell
-curl -u admin:supersecret "http://localhost:5000/health"
+curl -u admin:supersecret "http://localhost:5001/health"
 ```
 
 ## 📑 Logs

--- a/api.py
+++ b/api.py
@@ -130,4 +130,5 @@ def health():
 
 
 if __name__ == "__main__":
-    app.run(host="0.0.0.0", port=5000)
+    # The service is exposed on port 5001 via docker-compose and nginx
+    app.run(host="0.0.0.0", port=5001)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       - ./ssh/id_rsa:/root/.ssh/id_rsa:ro
     working_dir: /ansible
     expose:
-      - "5000:5000"
+      - "5001"
     networks:
       - my-network
 

--- a/utils.sh
+++ b/utils.sh
@@ -27,8 +27,6 @@ load_config() {
     fi
 }
 
-}
-
 check_dependencies() {
     local deps=(ansible sshpass python3-yaml jq curl)
     local missing=()


### PR DESCRIPTION
## Summary
- expose ansible_runner on port 5001
- update API to run on port 5001
- fix README curl examples
- remove stray brace in utils script

## Testing
- `bash -n utils.sh logger.sh Interactive_script.sh`
- `python3 -m py_compile api.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684adbb81a208329aba2c56422ebc601