### PR TITLE
Fix API endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,13 +56,13 @@ docker exec -it ansible_runner bash
 
 | Method | Endpoint  | Auth Required | Description            |
 | ------ | --------- | ------------- | ---------------------- |
-| GET    | `/health` | ✅             | API health check       |
-| POST   | `/run`    | ✅             | Trigger a playbook run |
+| GET    | `/api/health` | ✅             | API health check       |
+| POST   | `/api/run`    | ✅             | Trigger a playbook run |
 
 ### ▶️ Example: Run a playbook
 
 ```shell
-curl -X POST "http://localhost:5001/run" \
+ curl -X POST "http://localhost:5001/api/run" \
   -u admin:supersecret \
   -H "Content-Type: application/json" \
   -d '{"playbook": "playbook1.yml"}'
@@ -71,7 +71,7 @@ curl -X POST "http://localhost:5001/run" \
 ### ▶️ Example: Health check
 
 ```shell
-curl -u admin:supersecret "http://localhost:5001/health"
+ curl -u admin:supersecret "http://localhost:5001/api/health"
 ```
 
 ## 📑 Logs
@@ -101,7 +101,7 @@ chmod 600 ssh/id_rsa
 
 ## 🧩 Future Ideas
 
-- Token-based authentication work in proggres 🚧
-- Rate limiting work in proggres 🚧
-- User logging
-- Web dashboard - work in proggres 🚧
+ - Token-based authentication work in progress 🚧
+ - Rate limiting work in progress 🚧
+ - User logging
+ - Web dashboard - work in progress 🚧

--- a/api.py
+++ b/api.py
@@ -111,7 +111,7 @@ def run_playbook(playbook):
         return False, {"message": "An error occurred.", "error": str(e)}, 500
 
 
-@app.route("/run", methods=["POST"])
+@app.route("/api/run", methods=["POST"])
 @require_auth
 def run():
     data = request.get_json()


### PR DESCRIPTION
## Summary
- update README to match new API routes
- correct typos in the future ideas list
- change `api.py` routes to `/api/run`

## Testing
- `python3 -m py_compile api.py`

------
https://chatgpt.com/codex/tasks/task_e_684ae046a0f8832985ea02b1ed107a2d